### PR TITLE
first draft of contributing file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+## Welcome!
+
+We're so glad you're thinking about contributing to Transform to Open Science!
+
+Before contributing, we encourage you to read our CONTRIBUTING guide (you are here), our [LICENSE](https://github.com/nasa/Transform-to-Open-Science/blob/main/LICENSE.MD), our [README](https://github.com/nasa/Transform-to-Open-Science/blob/main/README.MD), and our [Code of Conduct](https://github.com/nasa/Transform-to-Open-Science/blob/main/CODE_OF_CONDUCT.MD), all of which should be in this repository.
+
+## Ways to Contribute
+
+If you do not already have a GitHub account, you can [sign up for GitHub here](https://github.com/). In the spirit of open source software, everyone is encouraged to help improve this project. Here are some ways you can contribute:
+- by reporting bugs
+- by suggesting new features
+- by translating content to a new language
+- by writing or editing documentation
+- by writing specifications
+- by writing code and documentation (**no pull request is too small**: fix typos, add code comments, clean up inconsistent whitespace)
+- by reviewing [pull requests](https://github.com/project-open-data/project-open-data-dashboard/pulls).
+- by closing issues
+
+#### Submit Great Issues
+* Before submitting a new [issue](https://github.com/nasa/Transform-to-Open-Science/issues), check to make sure [a similar issue isn't already open](https://github.com/nasa/Transform-to-Open-Science/issues?q=is%3Aopen+is%3Aissue). If one is, contribute to that issue thread with your feedback.
+* When submitting a bug report, please try to provide as much detail as possible, i.e. a screenshot or [gist](https://gist.github.com/) that demonstrates the problem, the technology you are using, and any relevant links. 
+
+#### Ready for your Help 
+Issues labeled :sparkles:[`help wanted`](https:/github.com/nasa/Transform-to-Open-Science/labels/help%20wanted):sparkles: make it easy for you to find ways you can contribute today. 
+
+## Development Model
+
+For accepting new contributions, TOPS uses the [forking workflow](https://guides.github.com/activities/forking/). As the first step of your contribution, you'll want to fork this repository, make a local clone of it, add your contribution, and then create a pull request back to the TOPS repository.  
+
+All documentation should be written using MarkDown.  
+
+## Public Domain
+
+This project constitutes a work of the United States Government and is not subject to domestic copyright protection under 17 USC § 105. Additionally, we waive copyright and related rights in the work worldwide through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+
+All contributions to this project will be released under the CC0
+dedication. By submitting a pull request, you are agreeing to comply
+with this waiver of copyright interest.


### PR DESCRIPTION
Add a first draft of a contributor guide.  The contributor guide is based on guide used in the https://github.com/GSA