### PR TITLE
Minor fix for link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Announcements!
 - OSTP releases [New Guidance to Ensure Federally Funded Research Data Equitably Benefits All of America](https://www.whitehouse.gov/ostp/news-updates/2022/05/26/new-guidance-to-ensure-federally-funded-research-data-equitably-benefits-all-of-america/)
-- AGU announces OpenCore [Leads](./docs/Area2_Capacity_Sharing/opencore/OpenCore_leads.md)
+- AGU announces OpenCore [Leads](./docs/Area2_Capacity_Sharing/OpenCore/OpenCore_leads.md)
 - [New Funding Opportunities](./docs/Area4_Moving_To_Openness/funding_opportunities.md)
 - [New Job Opportunities](./docs/Area4_Moving_To_Openness/job_opportunities.md)
 


### PR DESCRIPTION
I have been trying to access the [OpenCore leads](https://github.com/nasa/Transform-to-Open-Science/blob/main/docs/Area2_Capacity_Sharing/OpenCore/OpenCore_leads.md) from the main page, but it seems to be broken. I think someone renamed the folder from 'opencore' to 'OpenCore', lately 😄!