### PR TITLE
Patched Integer overflow in cmark-gfm leads to heap memory corruption CWE-190

### DIFF
--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
       execjs
     coffee-script-source (1.11.1)
     colorator (1.1.0)
-    commonmarker (0.17.13)
+    commonmarker (0.23.4)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.1.9)
     dnsruby (1.61.7)
@@ -126,7 +126,7 @@ GEM
       commonmarker (~> 0.14)
       jekyll (>= 3.7, < 5.0)
     jekyll-commonmark-ghpages (0.1.6)
-      commonmarker (~> 0.17.6)
+      commonmarker (~> 0.23.4)
       jekyll-commonmark (~> 1.2)
       rouge (>= 2.0, < 4.0)
     jekyll-default-layout (0.1.4)


### PR DESCRIPTION
CommonMarker uses ``cmark-gfm`` for rendering [Github Flavored Markdown](https://github.github.com/gfm/). An [integer overflow in ``cmark-gfm's`` table row parsing](https://github.com/github/cmark-gfm/security/advisories/GHSA-mc3g-88wq-6f4x) may lead to heap memory corruption when parsing tables who's marker rows contain more than UINT16_MAX columns. The impact of this heap corruption ranges from Information Leak to Arbitrary Code Execution.

If affected versions of CommonMarker are used for rendering remote user controlled markdown, this vulnerability may lead to Remote Code Execution (RCE).

## Patches
This vulnerability has been patched in the following CommonMarker release:
v0.23.4

## References
[GHSA-mc3g-88wq-6f4x](https://github.com/github/cmark-gfm/security/advisories/GHSA-mc3g-88wq-6f4x)
Acknowledgements
We would like to thank Felix Wilhelm of Google's Project Zero for reporting this vulnerability

## For more information
If you have any questions or comments about this advisory:

Open an issue in [CommonMarker](https://github.com/gjtorikian/commonmarker)