### PR TITLE
Add Open Science Lead at CarbonPlan to jobs

### DIFF
--- a/docs/Area4_Moving_To_Openness/job_opportunities.md
+++ b/docs/Area4_Moving_To_Openness/job_opportunities.md
@@ -10,3 +10,4 @@
 
 - [Lab Manager CIRES/Earth Lab, University of Colorado Boulder](https://jobs.colorado.edu/jobs/JobDetail/?jobId=41997)
 - [Postdoctoral Researcher CIRES/Earth Lab, University of Colorado Boulder](https://jobs.colorado.edu/jobs/JobDetail/CIRES-Earth-Lab-Post-Doctoral-Associate/36921)
+- [Open Science Lead, CarbonPlan](https://apply.workable.com/carbonplan/j/61E1AC0C31/)


### PR DESCRIPTION
Adds a link to the new job opportunity in open science - https://apply.workable.com/carbonplan/j/61E1AC0C31/