### PR TITLE
Update markdown headers to fix subsection display error in Jupyterbook toc

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,7 +40,7 @@ NASA prefers all communications to be in English.
 
 ## Policy
 
-NASA follows the principle of [Vulnerability Disclosure Policy]("https://www.nasa.gov/vulnerability-disclosure-policy").
+NASA follows the principle of [Vulnerability Disclosure Policy](https://www.nasa.gov/vulnerability-disclosure-policy).
 
 This vulnerability disclosure policy facilitates NASA’s awareness of otherwise unknown vulnerabilities. This policy is intended to give security researchers clear guidelines for conducting vulnerability discovery and disclosure activities to help NASA meet its objectives, and to convey how to submit discovered vulnerabilities to NASA.
 

--- a/Year_of_Open_Science_Cookbook/Engage_year_of_open_science.md
+++ b/Year_of_Open_Science_Cookbook/Engage_year_of_open_science.md
@@ -146,4 +146,4 @@ To help make this event a success, TOPS will provide organizations with the foll
 * Year of Open Science branding packet, including templates for stickers, presentation templates, Zoom backgrounds, and a guide for the use of NASA’s and TOPS’ logo and name
 
 ## Engage at Conferences
-Wish to invite others to engage with the Year of Open Science at your next conference? Navigate to the [TOPS Conferences Cookbook](/resources/year_of_open_science_cookbook/conferences_for_the_year_of_open_science.md) to learn how.
+Wish to invite others to engage with the Year of Open Science at your next conference? Navigate to the [TOPS Conferences Cookbook](./Year_of_Open_Science_Cookbook/conferences_for_the_year_of_open_science.md) to learn how.

--- a/_toc.yml
+++ b/_toc.yml
@@ -8,7 +8,6 @@ parts:
     - file: CODE_OF_CONDUCT
     - file: CONTRIBUTING
     - file: getting_started
-    - file: README
     - file: SECURITY
     - file: tops_faq
 - caption: Area 1 - Engagement  
@@ -31,7 +30,8 @@ parts:
     - file: docs/Area1_Engagement/Community_Forums/2022_Forums/20220714_community_forum
     - file: docs/Area1_Engagement/Community_Forums/2022_Forums/20220714_July_Forum_Responses
     - file: docs/Area1_Engagement/Community_Forums/2022_Forums/20220811_community_forum
-    - file: docs/Area1_Engagement/Community_Forums/2022_Forums/20220811_transcript
+      sections:
+        - file: docs/Area1_Engagement/Community_Forums/2022_Forums/20220811_transcript
     - file: docs/Area1_Engagement/Community_Forums/2022_Forums/20220908_community_forum
     - file: docs/Area1_Engagement/Community_Forums/2022_Forums/20221013_community_forum
     - file: docs/Area1_Engagement/Community_Forums/2022_Forums/20221110_community_forum  

--- a/_toc.yml
+++ b/_toc.yml
@@ -80,11 +80,11 @@ parts:
     - file: docs/Area2_Capacity_Sharing/OpenCore/images/image_location
     - file: docs/Area2_Capacity_Sharing/OpenCore/modules/Ethos_of_Open_Science_Module
       sections:
-      - file: docs/Area2_Capacity_Sharing/OpenCore/modules/open_data_module
-      - file: docs/Area2_Capacity_Sharing/OpenCore/modules/open_results_module
       - file: docs/Area2_Capacity_Sharing/OpenCore/modules/open_science_ethos_module
-      - file: docs/Area2_Capacity_Sharing/OpenCore/modules/open_software_module
       - file: docs/Area2_Capacity_Sharing/OpenCore/modules/open_tools_module
+      - file: docs/Area2_Capacity_Sharing/OpenCore/modules/open_data_module
+      - file: docs/Area2_Capacity_Sharing/OpenCore/modules/open_software_module
+      - file: docs/Area2_Capacity_Sharing/OpenCore/modules/open_results_module
   - file: docs/Area2_Capacity_Sharing/ScienceCore/readme
 - caption: Area 3 - Incentives  
   chapters:

--- a/docs/Area1_Engagement/Community_Forums/2022_Forums/20220811_community_forum.md
+++ b/docs/Area1_Engagement/Community_Forums/2022_Forums/20220811_community_forum.md
@@ -17,8 +17,8 @@ Then we will break out into smaller groups to have an in-depth discussion of eac
 - [Video Recording](https://www.youtube.com/watch?v=BgvIbzRsX-M)
 - [Slides](https://doi.org/10.5281/zenodo.6983153)
 - [What is Open Science? Word Art](https://doi.org/10.5281/zenodo.6986412)
-- [Transcript of Main Session](./Community_Forums/20220811_transcript.md) | [Anonymized Transcripts from Breakouts](https://doi.org/10.5281/zenodo.7023556)
-- [Code of conduct](../Community_Forums/code_of_conduct.md)
+- [Transcript of Main Session](./20220811_transcript.md) | [Anonymized Transcripts from Breakouts](https://doi.org/10.5281/zenodo.7023556)
+- [Code of conduct](../code_of_conduct.md)
 
 Tentative Agenda:
 | **Timestamp** | **Agenda Item** | **Speaker** |

--- a/docs/Area1_Engagement/Community_Forums/2022_Forums/20220811_transcript.md
+++ b/docs/Area1_Engagement/Community_Forums/2022_Forums/20220811_transcript.md
@@ -1,3 +1,5 @@
+# TOPS Community Forum - August 2022 transcript
+
 00:00:05:39 - 00:00:31:13
 Cynthia Hall
 So with regards to our code of conduct, we want to empower people, provide outstanding open science. And so this requires us to have an open exchange of ideas that are balanced by thoughtful guidelines, and it would be impossible for us to list everything that could create a more welcoming space for everyone. And we know this team will find ways to include colleagues that we haven't even thought of.

--- a/docs/Area1_Engagement/Community_Forums/readme.md
+++ b/docs/Area1_Engagement/Community_Forums/readme.md
@@ -3,7 +3,7 @@
 Approximately once a month, we hold a public meeting where we discuss parts of the TOPS mission, have guests who discuss their open science activities, or just talk about open science. We try to keep it interactive, with lots of questions and discussion. Come join us! Public participation always encouraged!
 
 ## Next Forum
-* November 10 2022 [Forum](./20221110_community_forum.md). 
+* November 10 2022 [Forum](./2022_Forums/20221110_community_forum.md). 
 
 ## Previous Forums
 

--- a/docs/Area2_Capacity_Sharing/Activity_Templates/workshops/readme.md
+++ b/docs/Area2_Capacity_Sharing/Activity_Templates/workshops/readme.md
@@ -6,7 +6,7 @@ Here is all you need for a self-organized workshop.
 
 TOPS welcomes you to organize and run your own workshop. Please connect with any of our trained instructors(TBD) who can teach the workshop. First, please notify us that you intend to organize a workshop by registering your workshop here(TBD). Most workshops will teach one or more modules from OpenCore.
 
-Start with our [workshop checklist](./logistics_checklist.md) and [logistic reminders](./logistics_checklist.md). Thank you to the Carpentries and their https://carpentries.org/workshops/ for getting us started! 
+Start with our [workshop checklist](./logistics_checklist.md) and [logistic reminders](./logistics_checklist.md). Thank you to the Carpentries and their [workshops](https://carpentries.org/workshops/) for getting us started! 
 
 # What are the requirements for a TOPS workshop?
 

--- a/docs/Area2_Capacity_Sharing/Activity_Templates/workshops/readme.md
+++ b/docs/Area2_Capacity_Sharing/Activity_Templates/workshops/readme.md
@@ -8,7 +8,7 @@ TOPS welcomes you to organize and run your own workshop. Please connect with any
 
 Start with our [workshop checklist](./logistics_checklist.md) and [logistic reminders](./logistics_checklist.md). Thank you to the Carpentries and their [workshops](https://carpentries.org/workshops/) for getting us started! 
 
-# What are the requirements for a TOPS workshop?
+## What are the requirements for a TOPS workshop?
 
 A TOPS workshop must meet the following requirements:
 

--- a/docs/Area2_Capacity_Sharing/OpenCore/modules/Ethos_of_Open_Science_Module.md
+++ b/docs/Area2_Capacity_Sharing/OpenCore/modules/Ethos_of_Open_Science_Module.md
@@ -7,7 +7,7 @@ The OpenCore open science curriculum will introduce those beginning their open s
 - Open Software
 - Open Results
 
-Modules are described in more detail [here](./OpenCore_structure.md).
+Modules are described in more detail [here](../OpenCore_structure.md).
 
 The TOPS Open Science Module Subject Matter Experts and Leads have been hard at work over the last several months working on the OpenCore modules and we are excited to share the initial draft of the [”Ethos of Open Science” module for public comment]. This initial comment phase will be open till Wednesday, September 28, 2022. 
 

--- a/docs/Area2_Capacity_Sharing/OpenCore/readme.md
+++ b/docs/Area2_Capacity_Sharing/OpenCore/readme.md
@@ -80,8 +80,8 @@ In order for the TOPS certification to be offered as part of in-person or virtua
 1 Apr 2023: In-person / virtual workshop materials and certification process for all modules \
 1 Apr 2023: MOOC and certification process 
 
-# Course Enrollment and Teaching Event Plan
-## Upcoming Events
+## Course Enrollment and Teaching Event Plan
+### Upcoming Events
 * December 10-13, 2022: Open Ethos module in-person workshops
 * January 7-12, 2022: Open Ethos module in-person workshops
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,6 +1,6 @@
 # Learn More About TOPS Activities
 
-- [Area 1: Engagement](./Area1_Engagement/): Building community, publishing articles, appearing on podcasts, expanding knowledge about open science, integrating Open Science into themes at large-scale events and conferences.
-- [Area 2: Capacity sharing](./Area2_Capacity_Sharing/): Producing online, free, open science curriculum, hosting workshops, events, cohorts, science team meetings, hackathons, and constructing multiple pathways to an Open Science Badge.
-- [Area 3: Incentives](./Area3_Incentives/): Developing Open Science Badge/Certification and establishing high profile awards in support of open science research.
-- [Area 4: Moving towards openness](./Area4_Moving_To_Openness/): Recognizing open science practices, holding open meetings, sharing hidden knowledge, and inclusive collaborations.
+- [Area 1: Engagement](./Area1_Engagement/readme.rst): Building community, publishing articles, appearing on podcasts, expanding knowledge about open science, integrating Open Science into themes at large-scale events and conferences.
+- [Area 2: Capacity sharing](./Area2_Capacity_Sharing/readme.md): Producing online, free, open science curriculum, hosting workshops, events, cohorts, science team meetings, hackathons, and constructing multiple pathways to an Open Science Badge.
+- [Area 3: Incentives](./Area3_Incentives/readme.md): Developing Open Science Badge/Certification and establishing high profile awards in support of open science research.
+- [Area 4: Moving towards openness](./Area4_Moving_To_Openness/readme.md): Recognizing open science practices, holding open meetings, sharing hidden knowledge, and inclusive collaborations.

--- a/tops_faq.md
+++ b/tops_faq.md
@@ -1,4 +1,4 @@
-<h2>Transform to Open Science (TOPS) Frequently Asked Questions </h2>
+# Transform to Open Science (TOPS) Frequently Asked Questions
 This page is a living document of the most common questions posed to the TOPS team. It is our hope that these answers will benefit the wider community. Further details can be found in the transcripts of our community events on our <a href = "https://github.com/nasa/Transform-to-Open-Science/tree/main/docs/Area1_Engagement/Community_Forums">community forum</a> and <a href = "https://github.com/nasa/Transform-to-Open-Science/tree/main/docs/Area1_Engagement/Community_Panels">community panel</a> pages.
 
 <details> 


### PR DESCRIPTION
This PR updates a couple markdown headers to fix some subsection (toggle menu) display errors in the sidebar table of contents (toc). Specifically, it seems that if there are multiple instances of a single "#" to denote "title" in a markdown file, the subsections of that page do not show up in the toc.

Additionally, I fixed a few broken links as I went through. 

