### PR TITLE
Jekyll site text updates

### DIFF
--- a/docs/Area2_Capacity_Sharing/Activity_Templates/readme.md
+++ b/docs/Area2_Capacity_Sharing/Activity_Templates/readme.md
@@ -6,17 +6,15 @@ The Transform to Open Science (TOPS) team knows that we are only a small part of
 - Want an example of successfully submitted talks...
 
 These resources are for you!
+- [TOPS graphics and other branding materials](https://github.com/nasa/Transform-to-Open-Science/tree/main/Organizing_OS_Activities/branding_and_graphics/readme.md)
+- [booth](https://github.com/nasa/Transform-to-Open-Science/tree/main/Organizing_OS_Activities/booth/readme.md)
+- [keynote](https://github.com/nasa/Transform-to-Open-Science/tree/main/Organizing_OS_Activities/keynote/readme.md)
+- [panel](https://github.com/nasa/Transform-to-Open-Science/tree/main/Organizing_OS_Activities/panel/readme.md)
+- [presentation](https://github.com/nasa/Transform-to-Open-Science/tree/main/Organizing_OS_Activities/presentation/readme.md)
+- [student conferences](https://github.com/nasa/Transform-to-Open-Science/tree/main/Organizing_OS_Activities/student_conference/readme.md)
+- [townhall or session](https://github.com/nasa/Transform-to-Open-Science/tree/main/Organizing_OS_Activities/townhall/readme.md)
+- [workshops](https://github.com/nasa/Transform-to-Open-Science/tree/main/Organizing_OS_Activities/workshops/readme.md)
 
-Resources:
-- [TOPS graphics and other branding materials](./branding_and_graphics/readme.md)
-- [booth](./booth/readme.md)
-- [keynote](./keynote/readme.md)
-- [panel](./panel/readme.md)
-- [presentation](./presentation/readme.md)
-- [student_conference](./student_conference/readme.md)
-- [townhall or session](./townhall/readme.md)
-- [workshops](./workshops/readme.md)
+To access our general open science resources including suggested trainings, publications, and like-minded organizations, head to our [Open Science Guide](/Open_Science_Cookbook/readme.md). 
 
-To access our general open science resources including suggested trainings, publications, and like-minded organizations, head to our [Open Science Cookbook](/Open_Science_Cookbook/readme.md). 
-
-Interested in activities to elevate the Year of Open Science? You can find those in your [Year of Open Science Cookbook](/Year_of_Open_Science_Cookbook/readme.md).
+Interested in activities to elevate the Year of Open Science? You can find those in your [Year of Open Science Collaboration Guide](/Year_of_Open_Science_Guide/readme.md) and in Section 2 of each chapter of the [Open Science Guide](/Open_Science_Cookbook/readme.md).

--- a/jekyll-site/_site/advance-open-science/index.html
+++ b/jekyll-site/_site/advance-open-science/index.html
@@ -150,7 +150,7 @@
 			<div class="article-post serif-font">
 				<p>TOPS is just getting started, and we want YOU to help us out!</p>
 
-<p>You can read more details about TOPS <a href="https://nasa.github.io/Transform-to-Open-Science/">here</a>, but the bottom line is that we have ambitious goals and need YOU and your organization to help make the transformation to open science a reality. We have many ways you can get involved with TOPS and we can help bring you tools and resources that will help create an open science infrastructure within your own organization.</p>
+<p>You can read more details about TOPS <a href="https://github.com/nasa/Transform-to-Open-Science/blob/main/index.md#transform-to-open-science">here</a>, but the bottom line is that we have ambitious goals and need YOU and your organization to help make the transformation to open science a reality. We have many ways you can get involved with TOPS and we can help bring you tools and resources that will help create an open science infrastructure within your own organization.</p>
 
 <h2 id="get-involved-now">Get involved now!</h2>
 
@@ -165,7 +165,7 @@
 
 <h2 id="contribute-to-our-github-repo">Contribute to our GitHub repo</h2>
 
-<p>Our GitHub repository (“repo”) is a one-stop shop for uncovering the many resources for open science that the TOPS team has put together! Our repo is also the base of our <a href="https://nasa.github.io/Transform-to-Open-Science/">JupyterBook</a> (draws from the same content as in the base GitHub repo, but in a more reader-friendly format!) and our website (build using a <a href="https://jekyllthemes.io">free Jekyll template</a> in conjunction with <a href="https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll">GitHub Pages</a>). Read on to learn more about how to use and help us maintain our GitHub repo so that it stays relevant for the open science community!</p>
+<p>Our GitHub repository (“repo”) is a one-stop shop for uncovering the many resources for open science that the TOPS team has put together! Our repo is also the base of our website (build using a <a href="https://jekyllthemes.io">free Jekyll template</a> in conjunction with <a href="https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll">GitHub Pages</a>). Read on to learn more about how to use and help us maintain our GitHub repo so that it stays relevant for the open science community!</p>
 
 <h3 id="types-of-contributions">Types of contributions</h3>
 
@@ -197,7 +197,7 @@
 
 <h2 id="frequently-asked-questions">Frequently Asked Questions</h2>
 
-<p>We have collected <a href="https://nasa.github.io/Transform-to-Open-Science/tops_faq.html">frequently asked questions</a>. Please use the discussions channel on this GitHub to ask more questions if you have them!</p>
+<p>We have collected <a href="https://github.com/nasa/Transform-to-Open-Science/blob/main/tops_faq.md">frequently asked questions</a>. Please use the discussions channel on this GitHub to ask more questions if you have them!</p>
 
 <h2 id="contact-us">Contact Us</h2>
 

--- a/jekyll-site/_site/start-doing-open-science/index.html
+++ b/jekyll-site/_site/start-doing-open-science/index.html
@@ -159,21 +159,21 @@
 
 <h2 id="are-you-new-to-open-science-this-month">Are you new to open science <em>this month</em>?</h2>
 
-<p>–&gt; Make your first pull request (PR) on GitHub! We will shortly have an interactive page on GitHub where you can make a PR and see your addition once your PR is approved! You can also follow these guidelines to contribute directly to the TOPS <a href="https://github.com/nasa/Transform-to-Open-Science">GitHub repository</a>, our <a href="https://nasa.github.io/Transform-to-Open-Science/">JupyterBook</a>, or our Jekyll website!</p>
+<p>–&gt; Make your first pull request (PR) on GitHub! We will shortly have an interactive page on GitHub where you can make a PR and see your addition once your PR is approved! You can also follow these guidelines to contribute directly to the TOPS <a href="https://github.com/nasa/Transform-to-Open-Science">GitHub repository</a>, which includes our Jekyll website!</p>
 
 <p>–&gt; Start learning an open-source programming language!<br />
    –&gt; <strong>Python</strong>: <a href="https://foundations.projectpythia.org/foundations/quickstart.html">Project Pythia’s “Zero to Python”</a> where you can run code interactively in your browser!<br />
    –&gt; <strong>R</strong>: <a href="https://r02pro.github.io/index.html#preface">“R Programming: Zero to Pro”</a></p>
 
-<p>–&gt; Find an open science community to join! Some communities are centered around scientific discipline, while others are focused around certain aspects of the open science process (e.g. open-source software). While each community functions differently, they often have guidelines about which software packages are used within a field, and forums for questions and discussions. See this <a href="https://nasa.github.io/Transform-to-Open-Science/Open_Science_Cookbook/Your_Open_Science_Journey.html#join-an-open-science-community">list of open science communities</a> - we have only just started this list, so please add your community if you don’t see it listed!</p>
+<p>–&gt; Find an open science community to join! Some communities are centered around scientific discipline, while others are focused around certain aspects of the open science process (e.g. open-source software). While each community functions differently, they often have guidelines about which software packages are used within a field, and forums for questions and discussions. See this <a href="https://github.com/nasa/Transform-to-Open-Science/blob/main/Open_Science_Cookbook/reading_list.md#open-science-communities-blogs-and-mentorship">list of open science communities</a> - we have only just started this list, so please add your community if you don’t see it listed!</p>
 
 <h2 id="are-you-new-to-open-science-this-year">Are you new to open science <em>this year</em>?</h2>
 
 <p>–&gt; Use what you’ve learned so far to help give back to the open science community! Answer questions in the <a href="https://github.com/nasa/Transform-to-Open-Science/discussions">TOPS GitHub Discussions space</a> (and in other open science community forums) or contribute to open-source software packages by opening issues and making pull requests.</p>
 
-<p>–&gt; With a year under your belt, consider helping TOPS promote open science at upcoming conferences and events! Making sure everyone is aware of othe benefits of open science will help the scientific community transform to a truly open and inclusive effort. TOPS has created some <a href="https://github.com/bello-mart-isabella/Transform-to-Open-Science/tree/GitBook_beautification/Organizing_OS_Activities">templates</a> that you can follow to organize a townhall, host a workshop, and much more!</p>
+<p>–&gt; With a year under your belt, consider helping TOPS promote open science at upcoming conferences and events! Making sure everyone is aware of othe benefits of open science will help the scientific community transform to a truly open and inclusive effort. TOPS has created some <a href="https://github.com/nasa/Transform-to-Open-Science/blob/main/Organizing_OS_Activities/readme.md">templates</a> that you can follow to organize a townhall, host a workshop, and much more!</p>
 
-<h2 id="ready-to-dive-in-deeper-read-through-the-tops-guide-to-open-science">Ready to dive in deeper? Read through the <a href="https://nasa.github.io/Transform-to-Open-Science/Open_Science_Cookbook/readme.html">TOPS Guide to Open Science</a>!</h2>
+<h2 id="ready-to-dive-in-deeper-read-through-the-tops-guide-to-open-science">Ready to dive in deeper? Read through the <a href="https://github.com/nasa/Transform-to-Open-Science/blob/main/Open_Science_Cookbook/Your_Open_Science_Journey.md">TOPS Guide to Open Science</a>!</h2>
 
                 <div class="clearfix"></div>
 			</div>

--- a/jekyll-site/_site/year-of-open-science/index.html
+++ b/jekyll-site/_site/year-of-open-science/index.html
@@ -177,7 +177,7 @@
   <li>Engage underrepresented communities in the advancement of open science</li>
 </ul>
 
-<h3 id="-learn-more-in-the-guide-to-nasas-year-of-open-science">–&gt; Learn more in the <a href="https://nasa.github.io/Transform-to-Open-Science/Year_of_Open_Science_Guide/readme.html">Guide to NASA’s Year of Open Science</a>!</h3>
+<h3 id="-learn-more-in-the-guide-to-nasas-year-of-open-science">–&gt; Learn more in the <a href="https://github.com/nasa/Transform-to-Open-Science/blob/main/Year_of_Open_Science_Guide/readme.md">Guide to NASA’s Year of Open Science</a>!</h3>
 
 <h2 id="how-to-start-the-open-science-journey-for">How to start the open science journey for…</h2>
 
@@ -185,22 +185,22 @@
 
 Are you just beginning your open science journey? Perhaps you have only just begun to post your code or data online, share your pre-prints, or share your null hypothesis as part of your grant application? Or perhaps you are exploring science communication on a personal blog. All of these behaviors exemplify open science and we would like for you to join us in the Year of Open Science! <br /><br />
 
-If you are excited to learn and encourage others to learn about open science as part of the Year of Open Science, then we invite you to check out the <a href="https://nasa.github.io/Transform-to-Open-Science/Open_Science_Cookbook/Your_Open_Science_Journey.html">Guide for Your Open Science Journey</a>!
+If you are excited to learn and encourage others to learn about open science as part of the Year of Open Science, then we invite you to check out the <a href="https://github.com/nasa/Transform-to-Open-Science/blob/main/Open_Science_Cookbook/Your_Open_Science_Journey.md#guide-for-your-open-science-journey">Guide for Your Open Science Journey</a>!
 </details>
 
 <details> <summary><span style="font-size:x-large;">Teams</span></summary>
 Is your team interested in adopting open science principles and practices, but unsure of how to begin? The Year of Open Science team activities could help you reflect together on how to equip the people at your organization with practical knowledge in open science, as well as introduce them to a wider community of open science practitioners.  <br /><br />
 
-Learn how to get your team involved with the <a href="https://nasa.github.io/Transform-to-Open-Science/Open_Science_Cookbook/Your_Teams_Open_Science_Journey.html">Guide for Your Team's Open Science Journey</a>!
+Learn how to get your team involved with the <a href="https://github.com/nasa/Transform-to-Open-Science/blob/main/Open_Science_Cookbook/Your_Teams_Open_Science_Journey.md#guide-for-your-teams-open-science-journey">Guide for Your Team's Open Science Journey</a>!
 </details>
 
 <details> <summary><span style="font-size:x-large;">Organizations</span></summary>
 
-Is your organization is ready to devote people, funds, and other resources to adopting open science throughout the organization. If your leaders are committed to becoming known as an open science organization, and excited to facilitate open science research through its policy and actions, then we invite you to explore the <a href="https://nasa.github.io/Transform-to-Open-Science/Open_Science_Cookbook/Your_Organizations_Open_Science_Journey.html">Guide for Your Organization's Open Science Journey</a>!
+Is your organization is ready to devote people, funds, and other resources to adopting open science throughout the organization. If your leaders are committed to becoming known as an open science organization, and excited to facilitate open science research through its policy and actions, then we invite you to explore the <a href="https://github.com/nasa/Transform-to-Open-Science/blob/main/Open_Science_Cookbook/Your_Organizations_Open_Science_Journey.md#guide-for-your-organizations-open-science-journey">Guide for Your Organization's Open Science Journey</a>!
 </details>
 
 <h2 id="join-us-at-conferences">Join Us At Conferences!</h2>
-<p>Does your organization host a conference? Navigate straight to our <a href="https://github.com/nasa/Transform-to-Open-Science/blob/main/docs/Area1_Engagement/Outreach/tops_conferences.md">Year of Open Science Conferences</a> page to learn more about how TOPS wishes to work with you.</p>
+<p>Does your organization host a conference? Navigate straight to our <a href="https://github.com/nasa/Transform-to-Open-Science/blob/main/Year_of_Open_Science_Guide/conferences_for_the_year_of_open_science.md#conferences-with-tops-for-the-year-of-open-science">Year of Open Science Conferences</a> page to learn more about how TOPS wishes to work with you.</p>
 
                 <div class="clearfix"></div>
 			</div>


### PR DESCRIPTION
Date: Dec 12, 2022
Purpose: Updated links in Jekyll site documentation that were causing "404" messages 
No pages were added or removed 