### PR TITLE
Added Links to SPD41a and AGU Presentations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 Want a website instead of a GitHub repo? [https://nasa.github.io/Transform-to-Open-Science/](https://nasa.github.io/Transform-to-Open-Science/)
 
-Ready to get started transforming towards open science with us? Get started [here!](./getting_started.md) 
+Ready to get started transforming towards open science with us? Get started [here!](./CONTRIBUTING.md) 
 
 Credit: <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-37-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 # Announcements!
-- [F.14 Transform to OPen Science Training (TOPST)](https://nspires.nasaprs.com/external/solicitations/summary.do?solId=%7bAB776446-03A8-4C24-845D-2E5A2ADA2D5A%7d&path=&method=init). **Proposals Due 12/8!**
-- NEW: TOPS will be at AGU Fall Meeting from Dec 11 through Dec 16! Check out [our agenda](https://doi.org/10.5281/zenodo.7411120) to learn where to hear our presentations, find our booth, and meet our team.
-- NEW: SMD's Data Portal has been [launched](https://science.data.nasa.gov/)! Explore NASA's science data as you explore open science. 
+- TOPS was at the AGU Fall meeting! If you missed us, you can find all our presentations on our [Zenodo](https://doi.org/10.5281/zenodo.7444034). If you met us at AGU and are just checking out our repo for the first time - Welcome! We are so excited you are here. 
+- NASA's new Science Information Policy has been released! You can find resources, frequently asked questions and the full text of the policy at [science.nasa.gov](https://science.nasa.gov/researchers/science-data/science-information-policy). At TOPS, we are especially excited about the [Open-Source Science Guidance for researchers funded by NASA's Science Mission Directorate](https://science.nasa.gov/science-red/s3fs-public/atoms/files/SMD%20Open-Source%20Science%20Guidance%20v1%2020221208.pdf)
+- SMD's Data Portal has been [launched](https://science.data.nasa.gov/)! Explore NASA's science data as you explore open science. 
 - Proposal [guidance](./docs/Area4_Moving_To_Openness/TOPST/proposal_resources.md)
 - Open Science funding [opportunities](./docs/Area4_Moving_To_Openness/funding_opportunities.md)
 - Open Science [stories](https://science.nasa.gov/open-science/transform-to-open-science/stories)

--- a/docs/Area1_Engagement/Outreach/tops_conferences.md
+++ b/docs/Area1_Engagement/Outreach/tops_conferences.md
@@ -4,7 +4,7 @@ Sync your calendar to ours using Google Calendar! [GCAL](https://calendar.google
 
 |Date |Conference |City | TOPS Conference Focus Area | 
 | - | - | - | - |
-|Dec 12 - 16, 2022 | American Geophysical Union (AGU) Fall Meeting ~ [Agenda](https://doi.org/10.5281/zenodo.7411120) | Chicago, IL | BPS, Planetary, Helio, Earth, Astro | 
+|Dec 12 - 16, 2022 | American Geophysical Union (AGU) Fall Meeting ~ [Agenda](https://doi.org/10.5281/zenodo.7411120) ~ TOPS AGU [Presentations](https://doi.org/10.5281/zenodo.7444034) | Chicago, IL | BPS, Planetary, Helio, Earth, Astro | 
 | Jan 8 - 12, 2023 | American Meteorological Society (AMS) | Denver, CO | Helio, Earth |
 | March 2 - 5, 2023 |American Association for the Advancement of Science (AAAS) Meeting | Washington, DC | BPS, Planetary, Helio, Earth, Astro |
 | March 13 - 17, 2023 | Lunar and Planetary Science Conference (LPSC) | Houston, TX | Planetary |

--- a/docs/Area4_Moving_To_Openness/funding_opportunities.md
+++ b/docs/Area4_Moving_To_Openness/funding_opportunities.md
@@ -1,21 +1,46 @@
-# Funding Opportunites for Pursuing Open Science
+# Funding Opportunities for Pursuing Open Science
+**Proposers should always consult [NSPIRES](https://nspires.nasaprs.com/external/) for the most accurate and up-to-date information on NASA proposals.**
 
-**9 Sept 2022 - TOPST:** NASA's Open Source Science Initiative ([OSSI](https://science.nasa.gov/open-science-overview)) welcomes proposals relevant to its goals to expand open science for the Science Mission Directorate. Application nformation can be found at this [link](https://nspires.nasaprs.com/external/solicitations/summary.do?solId=%7bAB776446-03A8-4C24-845D-2E5A2ADA2D5A%7d&path=&method=init). Optional Notice of Intent to Propose due 11/10/22. Proposals due 12/8/22. See the [TOPS Training FAQs](https://doi.org/10.5281/zenodo.7194641) for additional information. Proposals welcome for:
- - Development of ScienceCore materials (see Section 3.1),
- - Implementation of summer schools (see Section 3.2.1), and
- - Virtual cohorts (see Section 3.2.2).  
+### TOPS' proposal resources are available [here](/docs/Area4_Moving_To_Openness/TOPST/proposal_resources.md).
 
-Pre-proposal calls will be held Tuesday, October 25, 2022 and Thursday, November 3, 2022, 2-2:30 pm EST to provide interested parties with the opportunity to better understand the intent, scope, and selection criteria of the Transform to Open Science Training (Solicitation number NNH22ZDA001N-TOPST). This will be an open public question/answer period.
-
-You can attend this call in one of two ways: (i) Phone-in or (ii) Participate via WebEx. When using WebEx you can raise your hand via the chat room and follow up verbally, via chat when called upon, or just ask your questions by typing into the chat room. If you need the call in information or would like to add this to your own calendar, please download our [Meeting Calendar](https://github.com/nasa/Transform-to-Open-Science/tree/main/docs/Area1_Engagement).
-- October 25 [https://nasaenterprise.webex.com/nasaenterprise/j.php?MTID=m01280241e3f1332f4b1fb2ee300eed61](https://nasaenterprise.webex.com/nasaenterprise/j.php?MTID=m01280241e3f1332f4b1fb2ee300eed61)
-- November 3 [https://nasaenterprise.webex.com/nasaenterprise/j.php?MTID=m181c65b8777425f168a872e988670173](https://nasaenterprise.webex.com/nasaenterprise/j.php?MTID=m181c65b8777425f168a872e988670173)
-
-
-
-
-
-**12 May 2022:** NASA's Open Source Science Initiative ([OSSI](https://science.nasa.gov/open-science-overview)) welcomes proposals relevant to its goals to expand open science for the Science Mission Directorate. Application nformation can be found at this [link](https://nspires.nasaprs.com/external/solicitations/summary.do?solId=%7bC669B5EF-ACBB-A0E4-B57D-06F31DEABDB5%7d&path=&method=init). This is a rolling deadline through 12 May 2023. Additional information available in Section 3.6.1 at this [link](https://nspires.nasaprs.com/external/viewrepositorydocument?cmdocumentid=860804&solicitationId=%7BC669B5EF-ACBB-A0E4-B57D-06F31DEABDB5%7D&viewSolicitationDocument=1). Proposals welcome for
-- Events focused on SMD data, software, or open science practices
+## [F.2 Topical Workshops, Symposia, and Conferences](https://science.nasa.gov/researchers/sara/grant-solicitations/roses-2021/amendment-10-final-text-f2-topical-workshops-symposia-and-conferences)
+Events, Hackathons, un-conferences, and challenges that build open science skills, Training in open science. Rolling deadline.
+- Events focused on Science Mission Directorate data, software, or open science practices
 - Hackathons, un-conferences, and challenges that build open science skills
-- Training in open science
+- Focused training in open science practices and principles
+- Events MUST be openly available and allow for inclusive participation 
+- 5-page proposals for ROSES-22 will be accepted until May 13, 2023
+     - Potential proposers must confirm relevancy and availability of funds before preparing or submitting a proposal with a SMD program officer 
+
+## [F.7 Support for Open Source Tools, Frameworks, and Libraries](https://science.nasa.gov/researchers/solicitations/roses-2022/amendment-41-f7-support-open-source-tools-frameworks-and-libraries-deferred-roses-2023)
+Support and maintain open sources tools, frameworks, and libraries that are significantly used by the SMD community. $2M awarded in ROSES 20 to 8 programs, once every 3 years.
+- Improvements and sustainment of high-value, open source tools, frameworks, and libraries that have made significant impacts to the SMD science community
+- Proposals must:
+     - State the process of adding extensions, documentation, and maintenance of the software to support the user community
+     - Include an assessment of the potential impact to the SMD science community
+     - Proposals for ROSES-22 will be accepted until February 14, 202
+
+## [F.8 Supplemental Open Source Software Awards](https://nspires.nasaprs.com/external/solicitations/summary.do?solId={0BFB6C2C-5189-507A-FB82-E5A9869DF9E4}&path=&method=init)
+Supplemental award to encourage the conversion of legacy software to open source. Yearly, $250K available with a rolling deadline.
+- Conversion of legacy software into modern code with open license
+- Code released under a generally accepted, open source license
+- Proposer must have a research proposal selected for funding through any previous SMD solicitation with at least 15 months remaining in its period of performance at the time of the submission
+- Proposals for ROSES-22 will be accepted until March 29, 2023
+
+## F.14 Transform to Open Science Training
+Tutorials showcasing open science in action and NASA cloud data, summer schools, virtual cohorts. More information available [here](/docs/Area4_Moving_To_Openness/TOPST/readme.md).
+**The 2022 deadline for this opportunity has passed.** 
+
+## [F.15 High Priority Open-Source Science](https://science.nasa.gov/researchers/solicitations/roses-2022/amendment-73-f15-high-priority-open-source-science-final-text)
+Supporting innovative open source tools, software, frameworks, data formats, and libraries. Budget ~$1M. Yearly, rolling deadline.
+- Innovative open-source tools, software, frameworks, data formats, and libraries that will have a significant impact on the SMD science community
+- Small awards of ~$100k to support work for one year
+- Proposals may be submitted at any time until March 29, 2023
+
+## [F.16 Supplement for Software Platforms](https://science.nasa.gov/researchers/solicitations/roses-2022/amendment-72-f16-supplement-scientific-software-platforms-deferred-roses-2023)
+Supplemental support to existing awards for usage of scientific platforms. Budget TBD.
+- Supplemental support of existing awards for use of scientific analysis platforms
+- Scientific analysis platforms are defined as interactive environments accessible through a web browser providing access to data and computing resources to support scientific analysis and processing 
+- Deferred until ROSES 2023
+
+**TOPS' proposal resources are available [here](/docs/Area4_Moving_To_Openness/TOPST/proposal_resources.md).**

--- a/index.md
+++ b/index.md
@@ -2,13 +2,13 @@
 Welcome to the open science guide for Transform to Open Science (TOPS), a NASA Open-Source Science Initiative mission.
 
 ## Announcements!
-- [F.14 Transform to OPen Science Training (TOPST)](https://nspires.nasaprs.com/external/solicitations/summary.do?solId=%7bAB776446-03A8-4C24-845D-2E5A2ADA2D5A%7d&path=&method=init). **Proposals Due 12/8!**
-- Proposal [guidance](https://github.com/nasa/Transform-to-Open-Science/tree/main/docs/Area4_Moving_To_Openness/TOPST/proposal_resources.md)
-- Open Science funding [opportunities](https://github.com/nasa/Transform-to-Open-Science/tree/main/docs/Area4_Moving_To_Openness/funding_opportunities.md)
+- TOPS was at AGU Fall meeting! If you missed us, you can find all our presentations on our [Zenodo](https://doi.org/10.5281/zenodo.7444034). If you met us at AGU and are just checking out our repo for the first time - Welcome! We are so excited you are here. 
+- NASA's new Science Information Policy has been released! You can find resources, frequently asked questions and the full text of the policy at [science.nasa.gov](https://science.nasa.gov/researchers/science-data/science-information-policy). At TOPS, we are especially excited about the [Open-Source Science Guidance for researchers funded by NASA's Science Mission Directorate](https://science.nasa.gov/science-red/s3fs-public/atoms/files/SMD%20Open-Source%20Science%20Guidance%20v1%2020221208.pdf)
+- SMD's Data Portal has been [launched](https://science.data.nasa.gov/)! Explore NASA's science data as you explore open science. 
+- Proposal [guidance](./docs/Area4_Moving_To_Openness/TOPST/proposal_resources.md)
+- Open Science funding [opportunities](./docs/Area4_Moving_To_Openness/funding_opportunities.md)
 - Open Science [stories](https://science.nasa.gov/open-science/transform-to-open-science/stories)
-- [Job Opportunities](https://github.com/nasa/Transform-to-Open-Science/tree/main/docs/Area4_Moving_To_Openness/job_opportunities.md)
-- **NEW:** TOPS will be at AGU Fall Meeting from Dec 11 through Dec 16! Check out [our agenda](https://doi.org/10.5281/zenodo.7411120) to learn where to hear our presentations, find our booth, and meet our team.
-- **NEW:** SMD's Data Portal has been [launched](https://science.data.nasa.gov/)! Explore NASA's science data as you explore open science. 
+- [New Job Opportunities](./docs/Area4_Moving_To_Openness/job_opportunities.md)
 
 
 <img align="right" src="/docs/Area1_Engagement/branding_graphics/Tops_Badge_Nasa.png" width="300" alt="Transform to Open Science Logo that shows a top as a rocket taking off and the text Transform to Open Science in the white vapor plume around the launch site">


### PR DESCRIPTION
Date: Dec 15, 2022
Purpose: Added links to SPD-41a, TOPS and OSSI presentations from AGU and information from the new funding opportunities
Added/removed new pages - no 