### PR TITLE
Fixed the broken TOPS NASA logo reference in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Credit: <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section
 - [New Job Opportunities](./docs/Area4_Moving_To_Openness/job_opportunities.md)
 
 
-<img align="right" src="./docs/Area1_Engagement/branding_graphics/Tops_Badge_Nasa.png" width="300" alt="Transform to Open Science Logo that shows a top as a rocket taking off and the text Transform to Open Science in the white vapor plume around the launch site">
+<img align="right" src="https://zenodo.org/record/7742997/files/Tops_Badge_Nasa.png" width="300" alt="Transform to Open Science Logo that shows a top as a rocket taking off and the text Transform to Open Science in the white vapor plume around the launch site">
 
 # Transform to Open Science (TOPS)
 


### PR DESCRIPTION
The local version of Tops_Badge_Nasa.png was removed in commit a53cddd so the image reference in the README.md was broken. This has now been replaced with the correct version that is hosted on zenodo.org with all of the other graphics for the project.