### PR TITLE
Temporarily hide open science stories on main branch and fix typo in data management plan guidance page

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ You can [reach out to us using our contact form](https://docs.google.com/forms/d
 - Apply to become a local lead for the 2023 Space Apps challenge! Learn more [here](https://www.spaceappschallenge.org/).
 - SMD's Data Portal has been [launched](https://science.data.nasa.gov/)! Explore NASA's science data as you explore open science. 
 - Proposal [guidance](./docs/Area4_Moving_To_Openness/TOPST/proposal_resources.md)
+<!--
 - Open Science [stories](https://science.nasa.gov/open-science/transform-to-open-science/stories)
+-->
 
 ## Contributors ✨
 

--- a/docs/Area4_Moving_To_Openness/OSdmp.md
+++ b/docs/Area4_Moving_To_Openness/OSdmp.md
@@ -1,5 +1,5 @@
 
-Open Science and Data Managment Plan Guidance:
+Open Science and Data Management Plan Guidance:
 
 # USA
 - NASA Open Science and Data Management Plan


### PR DESCRIPTION
We will bring back the stories link once we decide on a place for these articles. The link was removed after web modernization. We have copies of those articles saved.

This commit also fixes a typo in the data management plan guidance page under Area 4.