### PR TITLE
Use latest actions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -11,11 +11,11 @@ jobs:
   deploy-book:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     # Install dependencies
     - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
 

--- a/.github/workflows/check_typos.yml
+++ b/.github/workflows/check_typos.yml
@@ -14,7 +14,7 @@ jobs:
         strategy:
             fail-fast: false
         steps:
-          - uses: actions/checkout@v3
+          - uses: actions/checkout@v4
           - uses: codespell-project/actions-codespell@master
             with:
               check_filenames: true


### PR DESCRIPTION
This PR updates two workflows to use the latest version of deprecated actions.
Currently action runs are issuing warning messages (for instance [see here](https://github.com/nasa/Transform-to-Open-Science/actions/runs/3651027254))