### PR TITLE
Removed data.gov from National Repositories list and replaced with other examples

### DIFF
--- a/Module_3/Lesson_2/readme.md
+++ b/Module_3/Lesson_2/readme.md
@@ -245,8 +245,9 @@ Note that some of our example search portals are also repositories, but not alwa
             <p>Data stored in these repositories are often produced by the government.</p>
             <p>Examples include:</p>
             <ul>
-                <li><a href="https://data.gov/">https://data.gov/</a></li>
-                <li><a href="https://data.europa.eu/en">https://data.europa.eu/en</a></li>
+                <li>Sweden: <a href="https://snd.se/en/catalogue/search">https://snd.se/en/catalogue/search</a></li>
+                <li>European Union: <a href="https://data.europa.eu/en">https://data.europa.eu/en</a></li>
+                <li>Australia: <a href="https://ada.edu.au/">https://ada.edu.au/</a></li>
             </ul>
         </td>
     </tr>

--- a/Module_3/Lesson_2/readme.md
+++ b/Module_3/Lesson_2/readme.md
@@ -245,9 +245,9 @@ Note that some of our example search portals are also repositories, but not alwa
             <p>Data stored in these repositories are often produced by the government.</p>
             <p>Examples include:</p>
             <ul>
-                <li>Sweden: <a href="https://snd.se/en/catalogue/search">https://snd.se/en/catalogue/search</a></li>
+                <li>Sweden: <a href="https://snd.se/en">https://snd.se/en</a></li>
                 <li>European Union: <a href="https://data.europa.eu/en">https://data.europa.eu/en</a></li>
-                <li>Australia: <a href="https://ada.edu.au/">https://ada.edu.au/</a></li>
+                <li>Australia: <a href="https://www.naa.gov.au">https://www.naa.gov.au</a></li>
             </ul>
         </td>
     </tr>


### PR DESCRIPTION
Swapped out data.gov in the national repository call-out b/c it isn't a repository. It is only a catalog. 
Added in the Australian and Swedish national repositories as other examples. 