### PR TITLE
M5 / L1  What is the Reproducibility Crisis

### DIFF
--- a/Module_5/Lesson_1/readme.md
+++ b/Module_5/Lesson_1/readme.md
@@ -166,9 +166,7 @@ We must consider the full research workflow if we are to solve the reproducibili
 
 <img src="../images/media/image15.png" style="width:350px;height:auto;" />
 
-By now, it should be obvious that there are many personal incentives to implement open science principles throughout all stages of the research process. By making results open throughout, you increase your ability to reproduce your own results.
-
-Although reproducibility of one's own results might sound like a trivial achievement, a [2016 Nature study](https://www.nature.com/articles/533452a) found that 50% of researchers are unable to reproduce their own experiments. This highlights the critical nature of the reproducibility crisis. This also has implications for research beyond the ability to improve your research.
+There are many personal incentives to implement open science principles throughout all stages of the research process. By making results open throughout, you increase your ability to reproduce your own results. This also has implications for research beyond the ability to improve your research.
 
 ### What is the Cause of This Reproducibility Crisis?
 


### PR DESCRIPTION
5/21: Within the section What is the Reproducibility Crisis, combine paragraph 3 and 4 by making the following edits:

Remove "By now it should be obvious that" and start the sentence with "There....". Then delete the first two sentences within the 4th paragraph. Lastly, move the third sentence from paragraph 4 to the end of paragraph 3.

New paragraph should be:

There are many personal incentives to implement open science principles throughout all stages of the research process. By making results open throughout, you increase your ability to reproduce your own results. This also has implications for research beyond the ability to improve your research.

---

@katblanchette This PR addresses Issue 9, from the OS101 team’s internal feedback mailbox and issue tracking system. Let me know when the OS101 developers get a chance to implement this in the MOOC. As always you can see the precise change in the 'files changed' tab above.