### PR TITLE
Translation suggestions

### DIFF
--- a/_includes/os101spanish/learn.html
+++ b/_includes/os101spanish/learn.html
@@ -6,9 +6,9 @@
           <div class="tops_half_section_imageoutter"><img src="{{ site.baseurl }}/assets/img/nativelanguage.jpg" class="tops_half_section_image"></div>
         </div>
         <div class="d-flex flex-column flex-wrap justify-content-center tops_half_section_column_big">
-          <h2 class="mb-2">Aprende Sobre Ciencia Abierta en su idioma Nativo</h2>
+          <h2 class="mb-2">Aprende sobre Ciencia Abierta en tu idioma nativo</h2>
           <div class="tops_divider div_smaller mb-3"><div class="div_inner"></div></div>
-          <p>Junto con un grupo de beneficiarios externos, TOPS lanzará próximamente una versión en español de nuestro curso Introducción a la Ciencia Abierta. Este curso está dirigido a investigadores de América Latina y de Estados Unidos que estén interesados en la Ciencia Abierta y en implementarla en su flujo de trabajo.</p>
+          <p>Junto a una colaboración externa, TOPS lanzará próximamente una versión en español de nuestro curso "Introducción a la Ciencia Abierta". Este curso está dirigido a personas hispanohablantes involucradas en investigación y con interés en aprender Ciencia Abierta e implementarla en su flujo de trabajo.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- Spanish capitalization works differently than in English
- Change from "usted" to "tu" for consistency
- Reworded "beneficiaries externos" for clarity and gender neutrality
- Reworded "investigators de América Latina y de Estados Unidos" for gender neutrality and inclusivity (Spanish speakers are mostly in the Americas, but not only there.