### PR TITLE
Translation suggestions

### DIFF
--- a/_layouts/spanish.html
+++ b/_layouts/spanish.html
@@ -104,11 +104,11 @@
       <div class="container tops_container">
         <div class="row">
           <div class="col-12 col-md-9 pe-0 pe-md-3">
-            <h2 class="text-white text-center text-md-start mb-2">Únase a la comunidad de ciencia abierta</h2>
-            <p class="text-white-85 text-center text-md-start mb-3 mb-md-0">Suscríbase a nuestro boletín informativo para mantenerse conectado con nuestra comunidad.</p>
+            <h2 class="text-white text-center text-md-start mb-2">Únete a la comunidad de Ciencia Abierta</h2>
+            <p class="text-white-85 text-center text-md-start mb-3 mb-md-0">Suscríbete a nuestro boletín informativo</p>
           </div>
           <div class="col-12 col-md-3 text-center text-md-end">
-            <a class="btn btn-primary" href="{{site.baseurl}}/{{site.signupbutton}}" target="_blank" role="button">Suscríbase Ahora</a>
+            <a class="btn btn-primary" href="{{site.baseurl}}/{{site.signupbutton}}" target="_blank" role="button">Suscríbete ahora</a>
           </div>
         </div>
       </div>
@@ -118,11 +118,11 @@
         <div class="tops_footer_columns">
           <div class="footer_column_big text-center text-lg-start">
             <a href="{{site.baseurl}}/" class="tops_footer_logo mb-4"><img class="" src="{{site.baseurl}}/{{site.footerlogo}}"></a>
-            <p class="tops_footer_bio text-center text-lg-start text-white-85 mb-0">La Iniciativa Transformar a la Ciencia Abierta (TOPS) de la NASA se complace en trabajar con una comunidad de científicos de diferentes disciplinas y orígenes. Al fomentar una cultura inclusiva de ciencia abierta, esperamos acelerar descubrimientos importantes, ampliar la participación de grupos históricamente excluidos y aumentar la adopción de principios de ciencia abierta. Lo alentamos a tomar nuestro curso de Introducción a la Ciencia Abierta para aumentar el impacto de sus investigaciones y esperamos saber de usted en nuestras discusiones de GitHub o a través de historias de éxito. Publicamos estas historias en nuestro boletín mensual.</p>
+            <p class="tops_footer_bio text-center text-lg-start text-white-85 mb-0">La iniciativa Transfórmate a la Ciencia Abierta (TOPS, por su sigla en inglés) de la NASA se complace en trabajar con una comunidad científica de diferentes disciplinas y orígenes. Al fomentar una cultura inclusiva de Ciencia Abierta, esperamos acelerar descubrimientos importantes, ampliar la participación de grupos históricamente excluidos y aumentar la adopción de principios de Ciencia Abierta. Te alentamos a tomar nuestro curso de "Introducción a la Ciencia Abierta" para aumentar el impacto de tus investigaciones y esperamos leer tus contribucionesa nuestras discusiones de GitHub o a través de historias de éxito. Publicamos estas historias en nuestro boletín mensual.</p>
           </div>
 
           <div class="footer_column_small">
-            <h3 class="text-white text-center text-lg-start">Paginas</h3>
+            <h3 class="text-white text-center text-lg-start">Páginas</h3>
             <div class="tops_divider div_smallest justify-content-center justify-content-lg-start mb-4"><div class="div_inner"></div></div>
             <ul class="footer_submenu">
               {% for footermenu-item in site.data.menus.footermenu_es %}
@@ -140,7 +140,7 @@
             </ul>
           </div>
           <div class="footer_column_small">
-            <h3 class="text-white text-center text-lg-start">Síganos</h3>
+            <h3 class="text-white text-center text-lg-start">Síguenos</h3>
             <div class="tops_divider div_smallest justify-content-center justify-content-lg-start mb-4"><div class="div_inner"></div></div>
             <div class="social_icons_footer d-flex flex-row flex-wrap justify-content-center justify-content-lg-start">
               {% if site.social.linkedin %}


### PR DESCRIPTION
- Changes capitalization
- Changes "usted" for "tu" for consistency and proximity with the audience
- Transform works differently in Spanish than in English. The Spanish contextualización opted to go with "Transfórmate a la Ciencia Abierta" to translate TOPS
- Used gender-neutral Spanish when it was not neutral